### PR TITLE
Add comment injection

### DIFF
--- a/languages/erlang/injections.scm
+++ b/languages/erlang/injections.scm
@@ -1,0 +1,2 @@
+((comment) @injection.content
+  (#set! injection.language "comment"))


### PR DESCRIPTION
With the comment language extension installed, this will highlight comments that start with TODO, FIXME, HACK, etc.