### PR TITLE
Add support for installing `erlang-ls`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 # zed-erlang
 #
 
+/grammars
 *.wasm
 
 #

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zed_erlang"
 version = "0.1.3"
-edition = "2021"
+edition = "2024"
 publish = false
 license = "Apache-2.0"
 

--- a/src/erlang.rs
+++ b/src/erlang.rs
@@ -24,13 +24,10 @@ impl zed::Extension for ErlangExtension {
     ) -> Result<zed::Command> {
         match language_server_id.as_ref() {
             ErlangLs::LANGUAGE_SERVER_ID => {
-                let erlang_ls = self.erlang_ls.get_or_insert_with(ErlangLs::new);
-
-                Ok(zed::Command {
-                    command: erlang_ls.language_server_binary_path(language_server_id, worktree)?,
-                    args: vec![],
-                    env: Default::default(),
-                })
+                let erlang_ls = self
+                    .erlang_ls
+                    .get_or_insert_with(ErlangLs::new);
+                erlang_ls.language_server_command(language_server_id, worktree)
             }
             ErlangLanguagePlatform::LANGUAGE_SERVER_ID => {
                 let erlang_language_platform = self

--- a/src/erlang.rs
+++ b/src/erlang.rs
@@ -24,9 +24,7 @@ impl zed::Extension for ErlangExtension {
     ) -> Result<zed::Command> {
         match language_server_id.as_ref() {
             ErlangLs::LANGUAGE_SERVER_ID => {
-                let erlang_ls = self
-                    .erlang_ls
-                    .get_or_insert_with(ErlangLs::new);
+                let erlang_ls = self.erlang_ls.get_or_insert_with(ErlangLs::new);
                 erlang_ls.language_server_command(language_server_id, worktree)
             }
             ErlangLanguagePlatform::LANGUAGE_SERVER_ID => {

--- a/src/language_servers.rs
+++ b/src/language_servers.rs
@@ -1,5 +1,6 @@
 mod erlang_language_platform;
 mod erlang_ls;
+mod util;
 
 pub use erlang_language_platform::*;
 pub use erlang_ls::*;

--- a/src/language_servers/erlang_language_platform.rs
+++ b/src/language_servers/erlang_language_platform.rs
@@ -2,6 +2,8 @@ use std::fs;
 
 use zed_extension_api::{self as zed, LanguageServerId, Result};
 
+use crate::language_servers::util;
+
 pub struct ErlangLanguagePlatform {
     cached_binary_path: Option<String>,
 }
@@ -102,14 +104,11 @@ impl ErlangLanguagePlatform {
             )
             .map_err(|e| format!("failed to download file: {e}"))?;
 
-            let entries =
-                fs::read_dir(".").map_err(|e| format!("failed to list working directory {e}"))?;
-            for entry in entries {
-                let entry = entry.map_err(|e| format!("failed to load directory entry {e}"))?;
-                if entry.file_name().to_str() != Some(&version_dir) {
-                    fs::remove_dir_all(entry.path()).ok();
-                }
-            }
+            util::remove_outdated_versions(
+                Self::LANGUAGE_SERVER_ID,
+                &otp_version,
+                &version_dir,
+            )?;
         }
 
         self.cached_binary_path = Some(binary_path.clone());

--- a/src/language_servers/erlang_language_platform.rs
+++ b/src/language_servers/erlang_language_platform.rs
@@ -119,11 +119,7 @@ impl ErlangLanguagePlatform {
             )
             .map_err(|e| format!("failed to download file: {e}"))?;
 
-            util::remove_outdated_versions(
-                Self::LANGUAGE_SERVER_ID,
-                &otp_version,
-                &version_dir,
-            )?;
+            util::remove_outdated_versions(Self::LANGUAGE_SERVER_ID, otp_version, &version_dir)?;
         }
 
         self.cached_binary_path = Some(binary_path.clone());

--- a/src/language_servers/erlang_language_platform.rs
+++ b/src/language_servers/erlang_language_platform.rs
@@ -38,10 +38,10 @@ impl ErlangLanguagePlatform {
             return Ok(path);
         }
 
-        if let Some(path) = &self.cached_binary_path {
-            if fs::metadata(path).is_ok_and(|stat| stat.is_file()) {
-                return Ok(path.clone());
-            }
+        if let Some(path) = &self.cached_binary_path
+            && fs::metadata(path).is_ok_and(|stat| stat.is_file())
+        {
+            return Ok(path.clone());
         }
 
         zed::set_language_server_installation_status(

--- a/src/language_servers/erlang_language_platform.rs
+++ b/src/language_servers/erlang_language_platform.rs
@@ -50,7 +50,7 @@ impl ErlangLanguagePlatform {
         );
 
         let (platform, arch) = zed::current_platform();
-        let otp_version = "28";
+        const OTP_VERSION: &str = "28";
 
         let release = match zed::latest_github_release(
             "WhatsApp/erlang-language-platform",
@@ -63,7 +63,7 @@ impl ErlangLanguagePlatform {
             Err(_) => {
                 if let Some(binary_path) = util::find_existing_binary(
                     Self::LANGUAGE_SERVER_ID,
-                    otp_version,
+                    OTP_VERSION,
                     Self::LANGUAGE_SERVER_ID,
                 ) {
                     self.cached_binary_path = Some(binary_path.clone());
@@ -81,7 +81,7 @@ impl ErlangLanguagePlatform {
             };
 
             format!(
-                "{}-{os}-{arch}-{os_target}-otp-{otp_version}.tar.gz",
+                "{}-{os}-{arch}-{os_target}-otp-{OTP_VERSION}.tar.gz",
                 Self::LANGUAGE_SERVER_ID,
                 arch = match arch {
                     zed::Architecture::Aarch64 => "aarch64",
@@ -102,7 +102,7 @@ impl ErlangLanguagePlatform {
             "{}-v{}-otp-{}",
             Self::LANGUAGE_SERVER_ID,
             release.version,
-            otp_version,
+            OTP_VERSION,
         );
         let binary_path = format!("{}/{}", version_dir, Self::LANGUAGE_SERVER_ID);
 
@@ -119,7 +119,7 @@ impl ErlangLanguagePlatform {
             )
             .map_err(|e| format!("failed to download file: {e}"))?;
 
-            util::remove_outdated_versions(Self::LANGUAGE_SERVER_ID, otp_version, &version_dir)?;
+            util::remove_outdated_versions(Self::LANGUAGE_SERVER_ID, OTP_VERSION, &version_dir)?;
         }
 
         self.cached_binary_path = Some(binary_path.clone());

--- a/src/language_servers/erlang_ls.rs
+++ b/src/language_servers/erlang_ls.rs
@@ -40,10 +40,10 @@ impl ErlangLs {
             return Ok(path);
         }
 
-        if let Some(path) = &self.cached_binary_path {
-            if fs::metadata(path).is_ok_and(|stat| stat.is_file()) {
-                return Ok(path.clone());
-            }
+        if let Some(path) = &self.cached_binary_path
+            && fs::metadata(path).is_ok_and(|stat| stat.is_file())
+        {
+            return Ok(path.clone());
         }
 
         zed::set_language_server_installation_status(

--- a/src/language_servers/erlang_ls.rs
+++ b/src/language_servers/erlang_ls.rs
@@ -2,6 +2,8 @@ use std::fs;
 
 use zed_extension_api::{self as zed, LanguageServerId, Result};
 
+use crate::language_servers::util;
+
 pub struct ErlangLs {
     cached_binary_path: Option<String>,
 }
@@ -103,14 +105,11 @@ impl ErlangLs {
             )
             .map_err(|e| format!("failed to download file: {e}"))?;
 
-            let entries =
-                fs::read_dir(".").map_err(|e| format!("failed to list working directory {e}"))?;
-            for entry in entries {
-                let entry = entry.map_err(|e| format!("failed to load directory entry {e}"))?;
-                if entry.file_name().to_str() != Some(&version_dir) {
-                    fs::remove_dir_all(entry.path()).ok();
-                }
-            }
+            util::remove_outdated_versions(
+                Self::LANGUAGE_SERVER_ID,
+                &otp_version,
+                &version_dir,
+            )?;
         }
 
         self.cached_binary_path = Some(binary_path.clone());

--- a/src/language_servers/erlang_ls.rs
+++ b/src/language_servers/erlang_ls.rs
@@ -1,21 +1,119 @@
+use std::fs;
+
 use zed_extension_api::{self as zed, LanguageServerId, Result};
 
-pub struct ErlangLs;
+pub struct ErlangLs {
+    cached_binary_path: Option<String>,
+}
 
 impl ErlangLs {
     pub const LANGUAGE_SERVER_ID: &'static str = "erlang-ls";
 
     pub fn new() -> Self {
-        Self
+        Self {
+            cached_binary_path: None,
+        }
     }
 
-    pub fn language_server_binary_path(
+    pub fn language_server_command(
         &mut self,
-        _language_server_id: &LanguageServerId,
+        language_server_id: &LanguageServerId,
+        worktree: &zed::Worktree,
+    ) -> Result<zed::Command> {
+        Ok(zed::Command {
+            command: self.language_server_binary_path(language_server_id, worktree)?,
+            args: vec!["server".to_string()],
+            env: Default::default(),
+        })
+    }
+
+    fn language_server_binary_path(
+        &mut self,
+        language_server_id: &LanguageServerId,
         worktree: &zed::Worktree,
     ) -> Result<String> {
-        worktree
-            .which("erlang_ls")
-            .ok_or_else(|| "erlang_ls must be installed and available on your $PATH".to_string())
+        if let Some(path) = worktree.which(Self::LANGUAGE_SERVER_ID) {
+            return Ok(path);
+        }
+
+        if let Some(path) = &self.cached_binary_path {
+            if fs::metadata(path).is_ok_and(|stat| stat.is_file()) {
+                return Ok(path.clone());
+            }
+        }
+
+        zed::set_language_server_installation_status(
+            language_server_id,
+            &zed::LanguageServerInstallationStatus::CheckingForUpdate,
+        );
+        let release = zed::latest_github_release(
+            "erlang-ls/erlang_ls",
+            zed::GithubReleaseOptions {
+                require_assets: true,
+                pre_release: false,
+            },
+        )?;
+
+        let (platform, _arch) = zed::current_platform();
+        let otp_version = match platform {
+            zed::Os::Mac | zed::Os::Linux => "27",
+            zed::Os::Windows => "26.2.5.3",
+        };
+        let asset_name = {
+            let os = match platform {
+                zed::Os::Mac => "macos",
+                zed::Os::Linux => "linux",
+                zed::Os::Windows => "windows",
+            };
+
+            format!(
+                "{}-{os}-{otp_version}.tar.gz",
+                Self::LANGUAGE_SERVER_ID.replace("-", "_"),
+            )
+        };
+
+        let asset = release
+            .assets
+            .iter()
+            .find(|asset| asset.name == asset_name)
+            .ok_or_else(|| format!("no asset found matching {:?}", asset_name))?;
+
+        let version_dir = format!(
+            "{}-v{}-otp-{}",
+            Self::LANGUAGE_SERVER_ID,
+            release.version,
+            otp_version,
+        );
+        let binary_path = format!(
+            "{}/{}",
+            version_dir,
+            Self::LANGUAGE_SERVER_ID.replace("-", "_"),
+        );
+
+        if !fs::metadata(&binary_path).is_ok_and(|stat| stat.is_file()) {
+            zed::set_language_server_installation_status(
+                language_server_id,
+                &zed::LanguageServerInstallationStatus::Downloading,
+            );
+
+            zed::download_file(
+                &asset.download_url,
+                &version_dir,
+                zed::DownloadedFileType::GzipTar,
+            )
+            .map_err(|e| format!("failed to download file: {e}"))?;
+
+            let entries =
+                fs::read_dir(".").map_err(|e| format!("failed to list working directory {e}"))?;
+            for entry in entries {
+                let entry = entry.map_err(|e| format!("failed to load directory entry {e}"))?;
+                if entry.file_name().to_str() != Some(&version_dir) {
+                    fs::remove_dir_all(entry.path()).ok();
+                }
+            }
+        }
+
+        self.cached_binary_path = Some(binary_path.clone());
+        Ok(binary_path)
     }
 }

--- a/src/language_servers/util.rs
+++ b/src/language_servers/util.rs
@@ -20,3 +20,27 @@ pub(super) fn remove_outdated_versions(
     }
     Ok(())
 }
+
+pub(super) fn find_existing_binary(
+    language_server_id: &'static str,
+    otp_version: &str,
+    binary: &str,
+) -> Option<String> {
+    fs::read_dir(".")
+        .ok()?
+        .flatten()
+        .filter_map(|entry| {
+            let path = entry.path();
+            if path.is_dir() && entry.file_name().to_str().is_some_and(|file_name| {
+                file_name.starts_with(language_server_id)
+                && file_name.ends_with(otp_version)
+            }) {
+                let binary_path = path.join(binary);
+                if binary_path.is_file() {
+                    return Some(binary_path.to_string_lossy().to_string());
+                }
+            }
+            None
+        })
+        .next()
+}

--- a/src/language_servers/util.rs
+++ b/src/language_servers/util.rs
@@ -12,8 +12,8 @@ pub(super) fn remove_outdated_versions(
         let entry = entry.map_err(|e| format!("failed to load directory entry {e}"))?;
         if entry.file_name().to_str().is_none_or(|file_name| {
             file_name.starts_with(language_server_id)
-            && file_name.ends_with(otp_version)
-            && file_name != version_dir
+                && file_name.ends_with(&format!("otp-{otp_version}"))
+                && file_name != version_dir
         }) {
             fs::remove_dir_all(entry.path()).ok();
         }
@@ -24,18 +24,20 @@ pub(super) fn remove_outdated_versions(
 pub(super) fn find_existing_binary(
     language_server_id: &'static str,
     otp_version: &str,
-    binary: &str,
+    binary_name: &str,
 ) -> Option<String> {
     fs::read_dir(".")
         .ok()?
         .flatten()
         .filter_map(|entry| {
             let path = entry.path();
-            if path.is_dir() && entry.file_name().to_str().is_some_and(|file_name| {
-                file_name.starts_with(language_server_id)
-                && file_name.ends_with(otp_version)
-            }) {
-                let binary_path = path.join(binary);
+            if path.is_dir()
+                && entry.file_name().to_str().is_some_and(|file_name| {
+                    file_name.starts_with(language_server_id)
+                        && file_name.ends_with(&format!("otp-{otp_version}"))
+                })
+            {
+                let binary_path = path.join(binary_name);
                 if binary_path.is_file() {
                     return Some(binary_path.to_string_lossy().to_string());
                 }

--- a/src/language_servers/util.rs
+++ b/src/language_servers/util.rs
@@ -1,0 +1,22 @@
+use std::fs;
+
+use zed_extension_api::Result;
+
+pub(super) fn remove_outdated_versions(
+    language_server_id: &'static str,
+    otp_version: &str,
+    version_dir: &str,
+) -> Result<()> {
+    let entries = fs::read_dir(".").map_err(|e| format!("failed to list working directory {e}"))?;
+    for entry in entries {
+        let entry = entry.map_err(|e| format!("failed to load directory entry {e}"))?;
+        if entry.file_name().to_str().is_none_or(|file_name| {
+            file_name.starts_with(language_server_id)
+            && file_name.ends_with(otp_version)
+            && file_name != version_dir
+        }) {
+            fs::remove_dir_all(entry.path()).ok();
+        }
+    }
+    Ok(())
+}

--- a/src/language_servers/util.rs
+++ b/src/language_servers/util.rs
@@ -26,23 +26,17 @@ pub(super) fn find_existing_binary(
     otp_version: &str,
     binary_name: &str,
 ) -> Option<String> {
-    fs::read_dir(".")
-        .ok()?
-        .flatten()
-        .filter_map(|entry| {
-            let path = entry.path();
-            if path.is_dir()
-                && entry.file_name().to_str().is_some_and(|file_name| {
-                    file_name.starts_with(language_server_id)
-                        && file_name.ends_with(&format!("otp-{otp_version}"))
-                })
-            {
-                let binary_path = path.join(binary_name);
-                if binary_path.is_file() {
-                    return Some(binary_path.to_string_lossy().to_string());
-                }
-            }
+    fs::read_dir(".").ok()?.flatten().find_map(|entry| {
+        let binary_path = entry.path().join(binary_name);
+
+        if binary_path.is_file()
+            && let Some(binary_dir) = entry.file_name().to_str()
+            && binary_dir.starts_with(language_server_id)
+            && binary_dir.ends_with(&format!("otp-{otp_version}"))
+        {
+            Some(binary_path.to_string_lossy().to_string())
+        } else {
             None
-        })
-        .next()
+        }
+    })
 }


### PR DESCRIPTION
Closes #1 - installs Erlang LS from the GitHub release assets

In addition to that, the following changes were also applied to both language servers:

 - Prevent the updating of a language server from deleting the installation of the other (adapted from zed-extensions/elixir#28)
 - Add a fallback to use a previously installed binary if downloading the latest GitHub release fails (adapted from zed-extensions/elixir#54)