### PR TITLE
Document custom Erlang LS setup on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ To develop this extension, see the [Developing Extensions](https://zed.dev/docs/
 
 ## Erlang/OTP version configuration option
 
-By default, the extension will download binaries corresponding to the latest Erlang/OTP version supported by the language server. You can specify which version to use instead via the `otp_version` option:
+By default, the extension downloads a language server binary for the latest supported Erlang/OTP version. The `settings.otp_version` option only selects which OTP-targeted language server binary the extension downloads; it does not configure the OTP installation used by your project or by a custom command.
 
 ```jsonc
   // Example for `erlang-ls`
@@ -32,4 +32,27 @@ By default, the extension will download binaries corresponding to the latest Erl
   }
 ```
 
-**NOTE:** This option _will not_ work for `erlang-ls` on Windows; the only binaries supplied for this platform are for `Erlang/OTP 26.2.5.3`.
+**NOTE:** On Windows, the automatic download for `erlang-ls` currently only provides a binary for `Erlang/OTP 26.2.5.3`, so `settings.otp_version` cannot select another version.
+
+### Using a custom `erlang-ls` command
+
+When the automatically selected binary does not match the OTP version you need, especially on Windows when that version is unavailable through automatic downloads, use Zed's generic binary override for the existing `erlang-ls` language server:
+
+```jsonc
+{
+  "lsp": {
+    "erlang-ls": {
+      "binary": {
+        "path": "C:/Program Files/Erlang OTP/erl-23/bin/escript.exe",
+        "arguments": [
+          "C:/path/to/compatible/erlang_ls",
+          "--transport",
+          "stdio"
+        ]
+      }
+    }
+  }
+}
+```
+
+The `binary.path` and `binary.arguments` values override the language server command and arguments. You are responsible for installing or building an `erlang_ls` escript that is compatible with your project's OTP version.


### PR DESCRIPTION
## Summary

- clarify that `settings.otp_version` selects the OTP-targeted language server asset downloaded by the extension, not the project's OTP installation
- document how Windows and older/fixed OTP projects can override the existing `erlang-ls` command with a compatible `escript.exe` and `erlang_ls` escript
- explain that users are responsible for installing or building an `erlang_ls` version compatible with their project OTP

## Context

This follows the guidance from zed-industries/extensions#6670 to contribute the Windows/project-specific OTP workflow to the existing Erlang extension instead of publishing a duplicate extension. The existing extension already supports `binary.path` and `binary.arguments`; this PR documents the working configuration.

## Validation

- `git diff --check upstream/main...HEAD`
- parsed the documented JSON example and verified the `escript.exe`, script path, `--transport`, `stdio` argument order
- ran a definition smoke test on Windows with OTP 23.3.4.20 and `erlang_ls` 0.48.1; the server returned the expected target file

`cargo check` was not run locally because Cargo is unavailable on this machine; this PR only changes `README.md`.